### PR TITLE
Update nvliblist.conf with the new cuda 10.2 libs

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -36,6 +36,7 @@
     - Geoffroy Vallee <geoffroy@sylabs.io>, <geoffroy.vallee@gmail.com>
     - George Hartzell <hartzell@alerce.com>
     - Gert Hulselmans <gert.hulselmans@kuleuven.vib.be>
+    - Götz Waschk <goetz.waschk@desy.de>
     - Hakon Enger <hakonenger@github.com>
     - Hugo Meiland <hugo.meiland@microsoft.com>
     - Ian Kaneshiro <ian@sylabs.io>, <iankane@umich.edu>

--- a/etc/nvliblist.conf
+++ b/etc/nvliblist.conf
@@ -29,6 +29,7 @@ libGLX_nvidia.so
 libglx.so
 libGLX.so
 libnvcuvid.so
+libnvidia-cbl.so
 libnvidia-cfg.so
 libnvidia-compiler.so
 libnvidia-eglcore.so
@@ -38,14 +39,18 @@ libnvidia-fatbinaryloader.so
 libnvidia-fbc.so
 libnvidia-glcore.so
 libnvidia-glsi.so
+libnvidia-glvkspirv.so
 libnvidia-gtk2.so
 libnvidia-gtk3.so
 libnvidia-ifr.so
 libnvidia-ml.so
 libnvidia-opencl.so
+libnvidia-opticalflow.so
 libnvidia-ptxjitcompiler.so
+libnvidia-rtcore.so
 libnvidia-tls.so
 libnvidia-wfb.so
+libnvoptix.so.1
 libOpenCL.so
 libOpenGL.so
 libvdpau_nvidia.so


### PR DESCRIPTION
## Description of the Pull Request (PR):
nvidia-container-cli lists more libs than currently in nvliblist.conf. This adds them as tested with cuda 10.2 on EL7.


### This fixes or addresses the following GitHub issues:

 - Fixes #4989


#### Before submitting a PR, make sure you have done the following:

- Read the [Guidelines for Contributing](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
- Added changes to the [CHANGELOG](https://github.com/sylabs/singularity/blob/master/CHANGELOG.md) if necessary according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added tests to validate this PR and tested this PR locally with a `make testall`
- Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/sylabs/singularity/blob/master/CONTRIBUTING.md)
- Added myself as a contributor to the [Contributors File](https://github.com/sylabs/singularity/blob/master/CONTRIBUTORS.md)


Attn: @singularity-maintainers

